### PR TITLE
Add Label atom component

### DIFF
--- a/src/atoms/Button/Button.tsx
+++ b/src/atoms/Button/Button.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, type ComponentPropsWithoutRef } from 'react';
 import styles from './Button.module.css';
+import { cn } from '../../utils/classNames';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'destructive';
 export type ButtonSize = 'small' | 'medium' | 'large';
@@ -81,17 +82,15 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       console.warn('Button: Icon-only buttons should have an aria-label for accessibility');
     }
 
-    const buttonClasses = [
+    const buttonClasses = cn(
       styles.button,
       styles[variant],
       styles[size],
       fullWidth && styles.fullWidth,
       loading && styles.loading,
       isIconOnly && styles.iconOnly,
-      className,
-    ]
-      .filter(Boolean)
-      .join(' ');
+      className
+    );
 
     return (
       <button

--- a/src/atoms/Label/Label.module.css
+++ b/src/atoms/Label/Label.module.css
@@ -1,0 +1,53 @@
+@import '../../styles/tokens.css';
+
+/* Base Label */
+.label {
+  display: inline-block;
+  font-family: var(--font-family);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-normal);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: color var(--transition-base);
+}
+
+/* Size Variants - Match Input component sizes */
+.small {
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--spacing-xs);
+}
+
+.medium {
+  font-size: var(--font-size-md);
+  margin-bottom: var(--spacing-xs);
+}
+
+.large {
+  font-size: var(--font-size-lg);
+  margin-bottom: var(--spacing-sm);
+}
+
+/* Required Indicator */
+.required {
+  color: var(--color-danger);
+  margin-left: var(--spacing-xs);
+  font-weight: var(--font-weight-bold);
+}
+
+/* Disabled State */
+.disabled {
+  color: var(--color-text-disabled);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.disabled .required {
+  color: var(--color-text-disabled);
+}
+
+/* Reduced Motion Support */
+@media (prefers-reduced-motion: reduce) {
+  .label {
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/atoms/Label/Label.stories.tsx
+++ b/src/atoms/Label/Label.stories.tsx
@@ -1,0 +1,323 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Label } from './Label';
+import { Input } from '../Input/Input';
+import '../../styles/tokens.css';
+
+const meta = {
+  title: 'Atoms/Label',
+  component: Label,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Form label atom. Provides accessible labels for form inputs with size variants, required indicators, and disabled states. Extends native HTML label props for full control.',
+      },
+    },
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['small', 'medium', 'large'],
+      description: 'Size variant to match associated input components',
+    },
+    required: {
+      control: 'boolean',
+      description: 'Display required indicator (red asterisk after text)',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disabled state styling',
+    },
+    htmlFor: {
+      control: 'text',
+      description: 'Associates label with input element by ID',
+    },
+    children: {
+      control: 'text',
+      description: 'Label text content',
+    },
+  },
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Username',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Default label with medium size.',
+      },
+    },
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'small',
+    children: 'Small Label',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Small size variant for compact forms.',
+      },
+    },
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    size: 'medium',
+    children: 'Medium Label',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Medium size variant (default).',
+      },
+    },
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'large',
+    children: 'Large Label',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Large size variant for prominent forms.',
+      },
+    },
+  },
+};
+
+export const Required: Story = {
+  args: {
+    children: 'Email Address',
+    required: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Label with required indicator (red asterisk) displayed after the text.',
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: 'Disabled Field',
+    disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Disabled state with reduced opacity and muted color.',
+      },
+    },
+  },
+};
+
+export const DisabledRequired: Story = {
+  args: {
+    children: 'Disabled Required Field',
+    disabled: true,
+    required: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Disabled label with required indicator.',
+      },
+    },
+  },
+};
+
+export const WithInput: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', minWidth: '300px' }}>
+      <Label htmlFor="username-input">Username</Label>
+      <Input id="username-input" placeholder="Enter your username" />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Label associated with an input using htmlFor. Clicking the label focuses the input.',
+      },
+    },
+  },
+};
+
+export const RequiredWithInput: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', minWidth: '300px' }}>
+      <Label htmlFor="email-input" required>
+        Email Address
+      </Label>
+      <Input id="email-input" type="email" placeholder="email@example.com" />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Required label with associated input field.',
+      },
+    },
+  },
+};
+
+export const DisabledWithInput: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', minWidth: '300px' }}>
+      <Label htmlFor="disabled-input" disabled>
+        Disabled Field
+      </Label>
+      <Input id="disabled-input" disabled placeholder="Cannot edit this field" />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Disabled label with disabled input field.',
+      },
+    },
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <div>
+        <Label size="small">Small Label</Label>
+      </div>
+      <div>
+        <Label size="medium">Medium Label</Label>
+      </div>
+      <div>
+        <Label size="large">Large Label</Label>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'All label size variants displayed together for comparison.',
+      },
+    },
+  },
+};
+
+export const AllStates: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <div>
+        <Label>Normal Label</Label>
+      </div>
+      <div>
+        <Label required>Required Label</Label>
+      </div>
+      <div>
+        <Label disabled>Disabled Label</Label>
+      </div>
+      <div>
+        <Label disabled required>
+          Disabled Required Label
+        </Label>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'All label states displayed together for comparison.',
+      },
+    },
+  },
+};
+
+export const FormExample: Story = {
+  render: () => (
+    <form style={{ display: 'flex', flexDirection: 'column', gap: '1rem', minWidth: '300px' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <Label htmlFor="form-name" required>
+          Full Name
+        </Label>
+        <Input id="form-name" name="name" placeholder="John Doe" fullWidth />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <Label htmlFor="form-email" required>
+          Email Address
+        </Label>
+        <Input id="form-email" name="email" type="email" placeholder="john@example.com" fullWidth />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <Label htmlFor="form-phone">Phone Number</Label>
+        <Input id="form-phone" name="phone" type="tel" placeholder="(555) 123-4567" fullWidth />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <Label htmlFor="form-website" disabled>
+          Website
+        </Label>
+        <Input
+          id="form-website"
+          name="website"
+          type="url"
+          placeholder="https://example.com"
+          disabled
+          fullWidth
+        />
+      </div>
+    </form>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Example form demonstrating labels with inputs in various states: required, optional, and disabled.',
+      },
+    },
+  },
+};
+
+export const SizeMatchingInputs: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem', minWidth: '300px' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <Label htmlFor="small-input" size="small">
+          Small Label
+        </Label>
+        <Input id="small-input" placeholder="Small input" fullWidth />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <Label htmlFor="medium-input" size="medium">
+          Medium Label
+        </Label>
+        <Input id="medium-input" placeholder="Medium input" fullWidth />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <Label htmlFor="large-input" size="large">
+          Large Label
+        </Label>
+        <Input id="large-input" placeholder="Large input" fullWidth />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Labels sized to match their associated input components for visual consistency.',
+      },
+    },
+  },
+};

--- a/src/atoms/Label/Label.test.tsx
+++ b/src/atoms/Label/Label.test.tsx
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Label } from './Label';
+
+describe('Label', () => {
+  describe('Rendering', () => {
+    it('renders with text content', () => {
+      render(<Label>Username</Label>);
+      expect(screen.getByText('Username')).toBeInTheDocument();
+    });
+
+    it('renders with children elements', () => {
+      render(
+        <Label>
+          Email <span data-testid="extra">*</span>
+        </Label>
+      );
+      expect(screen.getByText('Email')).toBeInTheDocument();
+      expect(screen.getByTestId('extra')).toBeInTheDocument();
+    });
+
+    it('applies custom className', () => {
+      render(<Label className="custom-class">Custom Label</Label>);
+      const label = screen.getByText('Custom Label');
+      expect(label).toHaveClass('custom-class');
+    });
+  });
+
+  describe('Sizes', () => {
+    it('renders medium size by default', () => {
+      const { container } = render(<Label>Medium</Label>);
+      const label = container.querySelector('label');
+      expect(label?.className).toMatch(/medium/);
+    });
+
+    it('renders small size', () => {
+      const { container } = render(<Label size="small">Small</Label>);
+      const label = container.querySelector('label');
+      expect(label?.className).toMatch(/small/);
+    });
+
+    it('renders large size', () => {
+      const { container } = render(<Label size="large">Large</Label>);
+      const label = container.querySelector('label');
+      expect(label?.className).toMatch(/large/);
+    });
+  });
+
+  describe('Required Indicator', () => {
+    it('does not show required indicator by default', () => {
+      render(<Label>Username</Label>);
+      expect(screen.queryByText('*')).not.toBeInTheDocument();
+    });
+
+    it('shows required indicator when required prop is true', () => {
+      render(<Label required>Username</Label>);
+      expect(screen.getByText('*')).toBeInTheDocument();
+    });
+
+    it('required indicator is aria-hidden for accessibility', () => {
+      render(<Label required>Username</Label>);
+      const asterisk = screen.getByText('*');
+      expect(asterisk).toBeInTheDocument();
+      expect(asterisk).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('required indicator appears after content', () => {
+      const { container } = render(<Label required>Username</Label>);
+      const label = container.querySelector('label');
+      expect(label?.textContent).toBe('Username*');
+    });
+  });
+
+  describe('Disabled State', () => {
+    it('applies disabled class when disabled prop is true', () => {
+      const { container } = render(<Label disabled>Disabled Label</Label>);
+      const label = container.querySelector('label');
+      expect(label?.className).toMatch(/disabled/);
+    });
+
+    it('does not apply disabled class by default', () => {
+      const { container } = render(<Label>Normal Label</Label>);
+      const label = container.querySelector('label');
+      expect(label?.className).not.toMatch(/disabled/);
+    });
+
+    it('applies disabled styling to required indicator', () => {
+      const { container } = render(
+        <Label disabled required>
+          Disabled Required
+        </Label>
+      );
+      const label = container.querySelector('label');
+      expect(label?.className).toMatch(/disabled/);
+      expect(screen.getByText('*')).toBeInTheDocument();
+    });
+  });
+
+  describe('Label Association', () => {
+    it('supports htmlFor attribute', () => {
+      render(<Label htmlFor="username-input">Username</Label>);
+      const label = screen.getByText('Username');
+      expect(label).toHaveAttribute('for', 'username-input');
+    });
+
+    it('works with associated input via htmlFor', () => {
+      render(
+        <div>
+          <Label htmlFor="test-input">Test Label</Label>
+          <input id="test-input" type="text" />
+        </div>
+      );
+      const label = screen.getByText('Test Label');
+      const input = screen.getByRole('textbox');
+      expect(label).toHaveAttribute('for', 'test-input');
+      expect(input).toHaveAttribute('id', 'test-input');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('renders as a label element', () => {
+      const { container } = render(<Label>Accessible Label</Label>);
+      const label = container.querySelector('label');
+      expect(label).toBeInTheDocument();
+      expect(label?.tagName).toBe('LABEL');
+    });
+
+    it('supports aria-label', () => {
+      render(<Label aria-label="Custom accessible label">Visible Text</Label>);
+      const label = screen.getByLabelText('Custom accessible label');
+      expect(label).toBeInTheDocument();
+    });
+
+    it('supports aria-describedby', () => {
+      render(
+        <div>
+          <Label aria-describedby="description">Label</Label>
+          <div id="description">This is a description</div>
+        </div>
+      );
+      const label = screen.getByText('Label');
+      expect(label).toHaveAttribute('aria-describedby', 'description');
+    });
+  });
+
+  describe('Forwarded Ref', () => {
+    it('forwards ref to label element', () => {
+      const ref = vi.fn();
+      render(<Label ref={ref}>Label with Ref</Label>);
+      expect(ref).toHaveBeenCalledWith(expect.any(HTMLLabelElement));
+    });
+  });
+
+  describe('Native Props', () => {
+    it('spreads additional props to label element', () => {
+      render(
+        <Label data-testid="custom-label" data-custom="value">
+          Label
+        </Label>
+      );
+      const label = screen.getByTestId('custom-label');
+      expect(label).toHaveAttribute('data-custom', 'value');
+    });
+
+    it('supports id attribute', () => {
+      render(<Label id="custom-id">Label</Label>);
+      expect(screen.getByText('Label')).toHaveAttribute('id', 'custom-id');
+    });
+
+    it('supports title attribute', () => {
+      render(<Label title="Tooltip text">Label</Label>);
+      expect(screen.getByText('Label')).toHaveAttribute('title', 'Tooltip text');
+    });
+  });
+
+  describe('Complex Children', () => {
+    it('renders multiple child elements', () => {
+      render(
+        <Label>
+          <span>First</span>
+          <span>Second</span>
+        </Label>
+      );
+      expect(screen.getByText('First')).toBeInTheDocument();
+      expect(screen.getByText('Second')).toBeInTheDocument();
+    });
+
+    it('handles mixed text and element children', () => {
+      render(
+        <Label>
+          Username <strong data-testid="strong">Required</strong>
+        </Label>
+      );
+      expect(screen.getByText('Username')).toBeInTheDocument();
+      expect(screen.getByTestId('strong')).toBeInTheDocument();
+    });
+  });
+
+  describe('Size and Required Combinations', () => {
+    it('renders small size with required indicator', () => {
+      const { container } = render(
+        <Label size="small" required>
+          Small Required
+        </Label>
+      );
+      const label = container.querySelector('label');
+      expect(label?.className).toMatch(/small/);
+      expect(screen.getByText('*')).toBeInTheDocument();
+    });
+
+    it('renders large size with disabled and required', () => {
+      const { container } = render(
+        <Label size="large" disabled required>
+          Large Disabled Required
+        </Label>
+      );
+      const label = container.querySelector('label');
+      expect(label?.className).toMatch(/large/);
+      expect(label?.className).toMatch(/disabled/);
+      expect(screen.getByText('*')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/atoms/Label/Label.tsx
+++ b/src/atoms/Label/Label.tsx
@@ -1,0 +1,49 @@
+import { forwardRef, type ComponentPropsWithoutRef } from 'react';
+import styles from './Label.module.css';
+import { cn } from '../../utils/classNames';
+
+export type LabelSize = 'small' | 'medium' | 'large';
+
+export interface LabelProps extends ComponentPropsWithoutRef<'label'> {
+  /**
+   * Size variant to match associated input components
+   * @default 'medium'
+   */
+  size?: LabelSize;
+
+  /**
+   * Display required indicator (red asterisk after text)
+   */
+  required?: boolean;
+
+  /**
+   * Disabled state styling
+   */
+  disabled?: boolean;
+}
+
+/**
+ * Label component - Form label atom
+ *
+ * Provides accessible labels for form inputs with size variants,
+ * required indicators, and disabled states.
+ * Extends native HTML label props for full control.
+ */
+export const Label = forwardRef<HTMLLabelElement, LabelProps>(
+  ({ size = 'medium', required = false, disabled = false, className, children, ...rest }, ref) => {
+    const labelClasses = cn(styles.label, styles[size], disabled && styles.disabled, className);
+
+    return (
+      <label ref={ref} className={labelClasses} {...rest}>
+        {children}
+        {required && (
+          <span className={styles.required} aria-hidden="true">
+            *
+          </span>
+        )}
+      </label>
+    );
+  }
+);
+
+Label.displayName = 'Label';

--- a/src/atoms/Label/index.ts
+++ b/src/atoms/Label/index.ts
@@ -1,0 +1,2 @@
+export { Label } from './Label';
+export type { LabelProps, LabelSize } from './Label';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ export { Button } from './atoms/Button';
 export type { ButtonProps, ButtonVariant, ButtonSize } from './atoms/Button';
 export { Input } from './atoms/Input';
 export type { InputProps } from './atoms/Input';
+export { Label } from './atoms/Label';
+export type { LabelProps, LabelSize } from './atoms/Label';
 
 // Molecules - Simple combinations
 // export { Card } from './molecules/Card';

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -23,6 +23,7 @@ const copyCSSPlugin = () => ({
 export default defineConfig({
   plugins: [react(), copyCSSPlugin()],
   build: {
+    emptyOutDir: false, // Don't delete .d.ts files from build:types
     lib: {
       entry: path.resolve(dirname, 'src/index.ts'),
       name: 'UWPokerClubComponents',


### PR DESCRIPTION
## Summary
This PR adds a new Label atom component following Atomic Design principles and addresses issue #19.

## Changes
- **New Label Component**: Implements a fully accessible form label with size variants, required indicator, and disabled states
  - Size variants (small, medium, large) matching Input component
  - Required indicator with proper `aria-hidden` semantics (visual asterisk only)
  - Disabled state styling
  - Extends native HTML label props via `ComponentPropsWithoutRef<'label'>`
  - Exports `LabelSize` type for programmatic usage

- **Comprehensive Testing**: 26 unit tests achieving 100% coverage
  - Rendering, sizes, required indicator, disabled state
  - Label association (htmlFor), accessibility, ref forwarding
  - Complex children and state combinations

- **Storybook Documentation**: 14 stories demonstrating all variants and use cases
  - Individual size and state variants
  - Integration examples with Input component
  - Form examples showing real-world usage

- **Code Quality Improvements**:
  - Refactored Button component to use `cn` utility for consistency
  - Fixed build configuration to preserve TypeScript declarations (`emptyOutDir: false`)

## Test Coverage
- All 170 tests passing (26 Label + 41 Button + 51 Input + 52 Storybook)
- 100% coverage on Label component
- No linting errors

## Accessibility
- Required indicator uses `aria-hidden="true"` (visual decoration only)
- Relies on associated input's `required` attribute for screen readers
- Follows ARIA Authoring Practices Guide recommendations

Resolves #19