### PR TITLE
Export components.css in package.json for component styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ pnpm add @uwpokerclub/components
 
 ## Usage
 
+### Importing Component Styles
+
+Import the component styles in your application's entry point (e.g., `main.tsx`, `_app.tsx`, or `layout.tsx`):
+
+```tsx
+// Import component styles
+import '@uwpokerclub/components/components.css';
+```
+
+This CSS file includes all the styles needed for the components to render correctly.
+
 ### Importing Components
 
 ```tsx

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
       "require": "./dist/index.cjs"
     },
     "./tokens.css": "./dist/styles/tokens.css",
+    "./components.css": "./dist/components.css",
     "./package.json": "./package.json"
   },
   "files": [
@@ -21,7 +22,9 @@
     "README.md",
     "LICENSE"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css"
+  ],
   "scripts": {
     "build": "npm run build:types && npm run build:lib",
     "build:lib": "vite build --config vite.config.lib.ts",


### PR DESCRIPTION
# Description

This PR fixes the missing CSS export in package.json that prevented consumers from importing component styles. The build process correctly generates `dist/components.css` (38KB), but it wasn't accessible to consumers.

Fixes #31

## Type of Change

- [x] `fix:` Bug fix (fixes an issue)

# Testing

- [x] Tested locally in Storybook
- [x] Manual testing performed
- [ ] Tested in consuming application (if applicable)

**Test details:**

Verified that `dist/components.css` exists and is generated correctly by the build process (38,634 bytes). The changes only affect package.json configuration - no code changes were made.

# Checklist

## Code Quality

- [x] Code follows the project's style guidelines
- [x] Ran `npm run lint` with no errors
- [x] Ran `npm run format` to format code
- [x] Ran `npm run build` successfully
- [x] All tests pass (`npm test`)
- [x] Test coverage meets the 80% threshold (check with `npm run test:coverage`)

## Component Requirements (if applicable)

N/A - This is a configuration change only

## Documentation

- [x] Code is self-documenting with clear variable/function names
- [x] README.md updated (if needed)

## Commits

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] PR title follows Conventional Commits format (e.g., `feat: Add new Button variant`)

# Additional Notes

**Changes made:**
1. Added `"./components.css": "./dist/components.css"` to package.json exports
2. Updated `sideEffects` from `false` to `["**/*.css"]` to prevent bundlers from tree-shaking CSS files

After this fix, consumers can import styles with:
```tsx
import { Table, Button } from '@uwpokerclub/components';
import '@uwpokerclub/components/components.css';
```