### PR TITLE
Add data-qa prop support to Table component

### DIFF
--- a/src/organisms/Table/Table.stories.tsx
+++ b/src/organisms/Table/Table.stories.tsx
@@ -399,3 +399,46 @@ export const CompactWithPagination: Story = {
     },
   },
 };
+
+/**
+ * Demonstrates the data-qa props feature for E2E testing.
+ * Use `headerProps`, `cellProps`, and `rowProps` to add data-qa attributes
+ * to table elements for reliable test selectors.
+ */
+export const WithDataQaAttributes: Story = {
+  args: {
+    columns: [
+      {
+        key: 'id',
+        header: 'ID',
+        accessor: 'id',
+        headerProps: { 'data-qa': 'id-header' },
+        cellProps: (row: User) => ({ 'data-qa': `user-id-${row.id}` }),
+      },
+      {
+        key: 'name',
+        header: 'Name',
+        accessor: 'name',
+        headerProps: { 'data-qa': 'name-header' },
+        cellProps: (row: User) => ({ 'data-qa': `user-name-${row.id}` }),
+      },
+      {
+        key: 'email',
+        header: 'Email',
+        accessor: 'email',
+        headerProps: { 'data-qa': 'email-header' },
+        cellProps: (row: User) => ({ 'data-qa': `user-email-${row.id}` }),
+      },
+      {
+        key: 'status',
+        header: 'Status',
+        accessor: 'status',
+        headerProps: { 'data-qa': 'status-header' },
+        cellProps: (row: User) => ({ 'data-qa': `user-status-${row.id}` }),
+      },
+    ],
+    data: sampleData,
+    sortable: true,
+    rowProps: (row: User) => ({ 'data-qa': `user-row-${row.id}` }),
+  },
+};

--- a/src/organisms/Table/Table.test.tsx
+++ b/src/organisms/Table/Table.test.tsx
@@ -337,4 +337,116 @@ describe('Table', () => {
 
     expect(screen.getByTestId('my-table')).toBeInTheDocument();
   });
+
+  describe('Data-qa props', () => {
+    it('passes headerProps to th elements', () => {
+      const columns: TableColumn<TestData>[] = [
+        {
+          key: 'name',
+          header: 'Name',
+          accessor: 'name',
+          headerProps: { 'data-qa': 'name-header' },
+        },
+        {
+          key: 'age',
+          header: 'Age',
+          accessor: 'age',
+          headerProps: { 'data-qa': 'age-header', className: 'custom-header' },
+        },
+      ];
+
+      render(<Table columns={columns} data={mockData} />);
+
+      const nameHeader = screen.getByText('Name').closest('th');
+      const ageHeader = screen.getByText('Age').closest('th');
+
+      expect(nameHeader).toHaveAttribute('data-qa', 'name-header');
+      expect(ageHeader).toHaveAttribute('data-qa', 'age-header');
+      expect(ageHeader?.className).toContain('custom-header');
+    });
+
+    it('passes cellProps to td elements', () => {
+      const columns: TableColumn<TestData>[] = [
+        {
+          key: 'name',
+          header: 'Name',
+          accessor: 'name',
+          cellProps: (row) => ({ 'data-qa': `name-cell-${String(row.id)}` }),
+        },
+      ];
+
+      render(<Table columns={columns} data={mockData} />);
+
+      const johnCell = screen.getByText('John Doe').closest('td');
+      const janeCell = screen.getByText('Jane Smith').closest('td');
+
+      expect(johnCell).toHaveAttribute('data-qa', 'name-cell-1');
+      expect(janeCell).toHaveAttribute('data-qa', 'name-cell-2');
+    });
+
+    it('passes rowProps to tr elements', () => {
+      render(
+        <Table
+          columns={mockColumns}
+          data={mockData}
+          rowProps={(row) => ({ 'data-qa': `row-${String(row.id)}` })}
+        />
+      );
+
+      const rows = screen.getAllByRole('row');
+      // First row is header, data rows start at index 1
+      expect(rows[1]).toHaveAttribute('data-qa', 'row-1');
+      expect(rows[2]).toHaveAttribute('data-qa', 'row-2');
+      expect(rows[3]).toHaveAttribute('data-qa', 'row-3');
+    });
+
+    it('cellProps receives the correct row data', () => {
+      const cellPropsFn = vi.fn((row: TestData) => ({
+        'data-qa': `cell-${String(row.id)}`,
+      }));
+      const columns: TableColumn<TestData>[] = [
+        {
+          key: 'name',
+          header: 'Name',
+          accessor: 'name',
+          cellProps: cellPropsFn,
+        },
+      ];
+
+      render(<Table columns={columns} data={mockData} />);
+
+      expect(cellPropsFn).toHaveBeenCalledTimes(3);
+      expect(cellPropsFn).toHaveBeenCalledWith(mockData[0]);
+      expect(cellPropsFn).toHaveBeenCalledWith(mockData[1]);
+      expect(cellPropsFn).toHaveBeenCalledWith(mockData[2]);
+    });
+
+    it('rowProps receives the correct row data', () => {
+      const rowPropsFn = vi.fn((row: TestData) => ({
+        'data-qa': `row-${String(row.id)}`,
+      }));
+
+      render(<Table columns={mockColumns} data={mockData} rowProps={rowPropsFn} />);
+
+      expect(rowPropsFn).toHaveBeenCalledTimes(3);
+      expect(rowPropsFn).toHaveBeenCalledWith(mockData[0]);
+      expect(rowPropsFn).toHaveBeenCalledWith(mockData[1]);
+      expect(rowPropsFn).toHaveBeenCalledWith(mockData[2]);
+    });
+
+    it('preserves selected class when rowProps adds className', () => {
+      render(
+        <Table
+          columns={mockColumns}
+          data={mockData}
+          selectable
+          rowProps={() => ({ className: 'custom-row' })}
+        />
+      );
+
+      const rows = screen.getAllByRole('row');
+      // Data rows start at index 1, should have custom-row class
+      expect(rows[1].className).toContain('custom-row');
+    });
+  });
 });


### PR DESCRIPTION
# Description

Add support for passing `data-qa` attributes to Table component elements (`<th>`, `<td>`, `<tr>`) for E2E testing purposes.

Closes #73

## Changes

- Add `headerProps` to `TableColumn` interface for passing props to `<th>` elements
- Add `cellProps` to `TableColumn` interface (function that receives row data and returns `<td>` props)
- Add `rowProps` to `TableProps` interface (function that receives row data and returns `<tr>` props)
- Use `cn()` utility for consistent className merging

## Example Usage

```tsx
const columns: TableColumn<User>[] = [
  {
    key: 'name',
    header: 'Name',
    accessor: 'name',
    headerProps: { 'data-qa': 'name-header' },
    cellProps: (row) => ({ 'data-qa': `name-cell-${row.id}` }),
  },
];

<Table
  columns={columns}
  data={users}
  rowProps={(row) => ({ 'data-qa': `user-row-${row.id}` })}
/>
```

## Type of Change

- [x] `feat:` New feature (adds functionality)

# Testing

- [x] Tested locally in Storybook
- [x] Unit tests added/updated and passing
- [x] Manual testing performed

**Test details:**

- Added 6 new tests covering headerProps, cellProps, rowProps functionality
- Tests verify props are passed correctly to DOM elements
- Tests verify row data is passed to callback functions
- Tests verify className merging works correctly with existing styles

# Checklist

## Code Quality

- [x] Code follows the project's style guidelines
- [x] Ran `npm run lint` with no errors
- [x] Ran `npm run format` to format code
- [x] Ran `npm run build` successfully
- [x] All tests pass (`npm test`)
- [x] Test coverage meets the 80% threshold (check with `npm run test:coverage`)

## Component Requirements (if applicable)

- [x] Component placed in correct Atomic Design category (atoms/molecules/organisms/templates)
- [x] Component follows the standard file structure (`.tsx`, `.test.tsx`, `.stories.tsx`, `.module.css`, `index.ts`)
- [x] Unit tests cover rendering, interactions, props, and accessibility
- [x] Storybook stories created with `tags: ['autodocs']`
- [x] Accessibility requirements met (WCAG 2.1 Level AA)
- [x] Component uses CSS variables from `src/styles/tokens.css` (no hardcoded values)
- [x] Component exported from component `index.ts` and main `src/index.ts`
- [x] TypeScript types properly defined and exported

## Documentation

- [x] Code is self-documenting with clear variable/function names
- [x] Complex logic includes comments explaining the "why"
- [x] JSDoc comments added for public APIs
- [x] Storybook documentation is clear and comprehensive

## Commits

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] PR title follows Conventional Commits format (e.g., `feat: Add new Button variant`)

# Additional Notes

This feature enables reliable E2E test selectors for table elements, which was identified as a need during UWPSC-33 (adding data-qa attributes to Members components).