### PR TITLE
feat(UWPSC-125): Add data-qa to Combobox options

### DIFF
--- a/src/molecules/Combobox/Combobox.tsx
+++ b/src/molecules/Combobox/Combobox.tsx
@@ -326,6 +326,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
                     id={`${comboboxId}-option-${String(index)}`}
                     role="option"
                     aria-selected={isSelected}
+                    data-qa={`combobox-option-${option.value}`}
                     className={cn(
                       styles.option,
                       isSelected && styles.selected,


### PR DESCRIPTION
# Description

Adds `data-qa="combobox-option-{value}"` to each `<li role="option">` in the Combobox component, enabling stable E2E test selectors in the website repo instead of fragile `cy.contains("[role='option']", text)` selectors.

## Type of Change

- [x] `feat:` New feature (adds functionality)

# Testing

- [ ] Tested locally in Storybook
- [x] Unit tests added/updated and passing
- [ ] Manual testing performed
- [ ] Tested in consuming application (if applicable)

**Test details:**

All 46 existing Combobox tests pass. The change is additive — it only adds a `data-qa` attribute to option `<li>` elements without affecting behavior.

# Checklist

## Code Quality

- [x] Code follows the project's style guidelines
- [x] Ran `npm run lint` with no errors
- [x] Ran `npm run format` to format code
- [x] Ran `npm run build` successfully
- [x] All tests pass (`npm test`)
- [ ] Test coverage meets the 80% threshold (check with `npm run test:coverage`)

## Documentation

- [x] Code is self-documenting with clear variable/function names

## Commits

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] PR title follows Conventional Commits format

# Additional Notes

This is a dependency for uwpokerclub/website UWPSC-125, which replaces fragile CSS selectors in Cypress E2E tests with `data-qa` attributes.